### PR TITLE
Add demo reel section to home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.DS_Store

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import HeroSection from "@/components/HeroSection";
 import ProjectCard from "@/components/ProjectCard";
+import DemoReel from "@/components/DemoReel";
 
 export default function HomePage() {
   return (
@@ -26,6 +27,8 @@ export default function HomePage() {
           />
         </div>
       </div>
+
+      <DemoReel />
     </section>
   );
 }

--- a/components/DemoReel.tsx
+++ b/components/DemoReel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { demos } from "@/content/demos";
+
+export default function DemoReel() {
+  return (
+    <section className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-3xl font-semibold">Demo Reel</h2>
+        <p className="max-w-2xl text-slate-600">
+          A curated mix of interactive prototypes showcasing motion, realtime rendering, and
+          storytelling moments. Each clip includes descriptive text to help everyone preview the
+          experience.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto pb-4 md:overflow-visible">
+        <div className="flex gap-6 md:grid md:grid-cols-2 md:gap-8 xl:grid-cols-3">
+          {demos.map((demo, index) => {
+            const summaryId = `demo-summary-${index}`;
+
+            return (
+              <article
+                key={demo.title}
+                className="group flex min-w-[280px] flex-1 flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-xl md:min-w-0"
+              >
+                <div
+                  className="animate-fade-in-up overflow-hidden rounded-xl bg-slate-900/5"
+                  style={{ animationDelay: `${index * 80}ms` }}
+                >
+                  <video
+                    className="h-48 w-full object-cover"
+                    src={demo.videoSrc}
+                    poster={demo.posterImage}
+                    controls
+                    preload="metadata"
+                    playsInline
+                    aria-describedby={summaryId}
+                  >
+                    Sorry, your browser doesn't support embedded videos.
+                  </video>
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold text-slate-900">{demo.title}</h3>
+                  <p id={summaryId} className="text-sm text-slate-600">
+                    {demo.summary}
+                  </p>
+                </div>
+
+                <p className="text-xs text-slate-500">
+                  Tip: Use the player controls to enable captions or enter full-screen mode.
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/content/demos.ts
+++ b/content/demos.ts
@@ -1,0 +1,33 @@
+export interface DemoMeta {
+  title: string;
+  summary: string;
+  videoSrc: string;
+  posterImage?: string;
+}
+
+export const demos: DemoMeta[] = [
+  {
+    title: "Generative City Builder",
+    summary:
+      "Procedurally assembles urban layouts in real time with adjustable density and terrain inputs.",
+    videoSrc: "https://storage.googleapis.com/coverr-main/mp4/Mt_Baker.mp4",
+    posterImage:
+      "https://images.unsplash.com/photo-1529429617124-aee3817f2c02?auto=format&fit=crop&w=1200&q=80",
+  },
+  {
+    title: "Product Customizer",
+    summary:
+      "AR-enhanced configurator that lets shoppers preview material swaps instantly across devices.",
+    videoSrc: "https://storage.googleapis.com/coverr-main/mp4/Namaste.mp4",
+    posterImage:
+      "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80",
+  },
+  {
+    title: "Voice-Driven Analytics",
+    summary:
+      "Conversational assistant that narrates dashboards, highlights anomalies, and exports narrated clips.",
+    videoSrc: "https://storage.googleapis.com/coverr-main/mp4/Bowl.mp4",
+    posterImage:
+      "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80",
+  },
+];

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,21 @@
   .animation-delay-4000 {
     animation-delay: 4s;
   }
+
+  .animate-fade-in-up {
+    opacity: 0;
+    transform: translateY(12px);
+    animation: fade-in-up 0.6s ease-out forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-in-up {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  }
+
 }
 
 @keyframes blob {
@@ -34,5 +49,16 @@
   }
   100% {
     transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }


### PR DESCRIPTION
## Summary
- create structured demo metadata and a DemoReel component that renders responsive, accessible video tiles
- add a reusable fade-in animation utility for the reel entries and ignore common build artifacts
- display the demo reel beneath the featured projects on the homepage for easy discovery

## Testing
- npm run dev *(fails: Cannot find module '@mdx-js/loader')*

